### PR TITLE
Dec 2014 statement format update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Reads Barclays Bank statements and extracts transactions. Validates transactions
 
 Tested against 18 months' worth of bank statements exported in September 2014.
 
+[UPDATE: April 2015]
+The statement format was updated in December 2014.
+Therefore the updated app has only been tested on four months of statements.
+You should check every statement you convert. There may be some transaction types that have not been encountered, and need to be added, and some possible varients on the layout that are not taken account of.
+If you find an entry that is not picked up by the application, please open an issue on Github with the text of the entry description only. Do not share your unedited bank statements with anyone for obvious security reasons.
+
 Built on [Mozilla PDF.JS](http://mozilla.github.io/pdf.js/), which is marvellous.
 
 In-browser version online at: http://penrosestudio.com/barclays-bank-pdf-to-csv/

--- a/README.md
+++ b/README.md
@@ -7,9 +7,16 @@ Reads Barclays Bank statements and extracts transactions. Validates transactions
 
 Tested against 18 months' worth of bank statements exported in September 2014.
 
+[UPDATE: April 2015]
+The statement format was updated in December 2014.
+Therefore the updated app has only been tested on four months of statements.
+You should check every statement you convert. There may be some transaction types that have not been encountered, and need to be added, and some possible varients on the layout that are not taken account of.
+If you find an entry that is not picked up by the application, please open an issue on Github with the text of the entry description only. Do not share your unedited bank statements with anyone for obvious security reasons.
+
 Built on [Mozilla PDF.JS](http://mozilla.github.io/pdf.js/), which is marvellous.
 
 In-browser version online at: http://penrosestudio.com/barclays-bank-pdf-to-csv/
+[Does not include 2015 update]
 
 ## Installation
 

--- a/statement-parser-lib.js
+++ b/statement-parser-lib.js
@@ -166,20 +166,28 @@
     "Debit card payment to",
     "Direct debit to",
     "Card Payment",
+    "Credit Payment",
     "Internet Banking transfer to",
     "On-line Banking bill payment to",
     "Commission charges",
     "Standing order to",
-    "Cash machine withdrawal"
+    "Cash machine withdrawal",
+    "Cheque issued"
   ];
   var receipts = [
     "Direct credit from",
     "Debit card refund from",
     "Internet Banking transfer from",
     "Deposit", // NB: not sure this is a generic reference
-    "Refund from"
+    "Refund from",
+    "Business Banking Loyalty Reward"
   ];
-  var transactionsStart = 'Transactions in date order\\nDate\tDescription\tPayments\tReceipts\tBalance';
+
+  var transactionsStart = [
+                            'Transactions in date order\\nDate\tDescription\tPayments\tReceipts\tBalance',//Old statement format
+                            'Your Business Current Account',
+                            'Continued\\n'
+                          ];
   /*
   transaction ending patterns are:
   * Interim balance carried forward3,856.88 - used on first page when a day's transaction spill over to the second page
@@ -192,7 +200,7 @@
   var optionalDateMarker = '(?:(\\d{1,2} [a-zA-z]{3})\t)?'; // some transactions are preceded by dates such as '7 Feb' or '21 Jul'
   var amountMarker = '\t[\\d,]+\\.\\d\\d';
   var trailingBalanceMarker = '(?:[\\d,]+\\.\\d\\d)?'; // some transactions are followed by balances that can interfere a subsequent date e.g. 'Direct credit from G Kirschner Ref:-KirschnerBooking306.004,109.18' followed by '7 FebDebit card payment...'
-  var transactionSeparator = new RegExp(optionalDateMarker+'(('+paymentsMarkers+'|'+receiptsMarkers+').+?)('+amountMarker+')'+trailingBalanceMarker,'g');
+  var transactionSeparator = new RegExp(optionalDateMarker+'(('+paymentsMarkers+'|'+receiptsMarkers+').+?)('+amountMarker+')'+trailingBalanceMarker,'gi');
   var totalsMarker = new RegExp('Total payments - incl\\.\\\\ncommission & interest('+amountMarker+').+?Total receipts('+amountMarker+')');
   //console.info('transaction separator',transactionSeparator);
 
@@ -208,9 +216,21 @@
       }
     }
     // extract statement lines
-    var startIndex = text.indexOf(transactionsStart),
+    var startIndex,
+        loopStartIndex,
         //endIndex = text.search(transactionsEnd),
         matches;
+    for (var i = transactionsStart.length - 1; i >= 0; i--) {
+      loopStartIndex = text.indexOf(transactionsStart[i]);
+
+      if(loopStartIndex > -1){
+        startIndex = loopStartIndex;
+      }
+    };
+    if(typeof startIndex === 'undefined'){
+      startIndex = -1;
+    }
+
     //if(endIndex===-1 || startIndex===-1) {
     if(startIndex===-1) {
       console.warn('could not find start of transactions in text, skipping page '+pageNum);


### PR DESCRIPTION
Around December Barclays introduced new format statements. Fortunately for the purposes of this script, the changes were relatively minor.

I have also added some new delimiters - yes, cheques are still a thing! I haven't received a cheque payment, so I don't know how they appear. It would be great to a get a definitive list, but any list will eventually become obsolete.

As a result, it is important that users of this script check EVERY entry in the CSV against the statement. If a transaction is found that the script is not detecting, opening a Github issue with the text of the transaction would be greatly appreciated.

One important change is making the transactionSeparator regex case insensitive - Direct Debit is now written in title case on the statement (which it probably always should have been), so the previous commit missed all Direct Debits.

Add new payment and receipt delimiters
Add new transaction start delimiters - turning transactionStart into array
Make regex case insensitive

Update startIndex assignment to loop through transacactionStart array
